### PR TITLE
Add pkl barcodes to installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include barcodes/*.csv
+include barcodes/*.pkl

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'matplotlib',
     ],
     zip_safe=False,
-    package_data={'split_seq': ['barcodes/*.csv', 'rRNA.fa']},
+    package_data={'split_seq': ['barcodes/*.csv', 'barcodes/*.pkl', 'rRNA.fa']},
     include_package_data=True,
     # TODO: commenting this out; the user can run install_dependencies on their own.
     #cmdclass={'install': CustomInstall},


### PR DESCRIPTION
Currently the installation of `split-seq-pipeline` lacks the pkl barcodes, which causes `FileNotFoundError` errors. This PR adds those files to the installation package.