### PR TITLE
Fix for read assignment bug

### DIFF
--- a/split_seq/processv2.py
+++ b/split_seq/processv2.py
@@ -284,24 +284,25 @@ def molecule_info_chunk(transcriptome_dir, output_dir, chunk=None, gtf_dict_step
             sys.stdout.flush()
 
     # Handle the data for the last cell barcode combination
-    df = pd.DataFrame({'cell_barcodes':cell_barcodes,
-                       'umi':umis,
-                       'gene':pd.Series(genes),
-                       'exonic':exonic_assignments,
-                       'umi_quality':umi_quals})
-    df_collapsed = collapse_umis_dataframe(df)
-    df_collapsed = df_collapsed.reset_index()
-    df_collapsed.columns = ['gene','umi','counts']
-    exonic_fraction = df.groupby(['gene','umi']).exonic.mean()
-    df_collapsed.loc[:,'exonic'] = exonic_fraction.loc[list(zip(df_collapsed.gene.values,
-                                                             df_collapsed.umi.values))].values>0.5
-    df_collapsed['cell_barcode'] = cell_barcodes[0]
-    df_collapsed.loc[:,'gene_name'] = df_collapsed.gene.apply(lambda s:gene_id_to_name[s])
-    df_collapsed.loc[:,'genome'] = df_collapsed.gene.apply(lambda s:gene_id_to_genome[s])
-    df_collapsed[['cell_barcode','genome','gene','gene_name','umi','counts','exonic']].to_csv(output_filename,
-                                                   header=False,
-                                                   index=False,
-                                                   mode='a')
+    if c>0:
+        df = pd.DataFrame({'cell_barcodes':cell_barcodes,
+                           'umi':umis,
+                           'gene':pd.Series(genes),
+                           'exonic':exonic_assignments,
+                           'umi_quality':umi_quals})
+        df_collapsed = collapse_umis_dataframe(df)
+        df_collapsed = df_collapsed.reset_index()
+        df_collapsed.columns = ['gene','umi','counts']
+        exonic_fraction = df.groupby(['gene','umi']).exonic.mean()
+        df_collapsed.loc[:,'exonic'] = exonic_fraction.loc[list(zip(df_collapsed.gene.values,
+                                                                 df_collapsed.umi.values))].values>0.5
+        df_collapsed['cell_barcode'] = cell_barcodes[0]
+        df_collapsed.loc[:,'gene_name'] = df_collapsed.gene.apply(lambda s:gene_id_to_name[s])
+        df_collapsed.loc[:,'genome'] = df_collapsed.gene.apply(lambda s:gene_id_to_genome[s])
+        df_collapsed[['cell_barcode','genome','gene','gene_name','umi','counts','exonic']].to_csv(output_filename,
+                                                       header=False,
+                                                       index=False,
+                                                       mode='a')
 
     samfile.close()
 

--- a/split_seq/processv2.py
+++ b/split_seq/processv2.py
@@ -282,6 +282,27 @@ def molecule_info_chunk(transcriptome_dir, output_dir, chunk=None, gtf_dict_step
         if d%100000==0:
             print('Processed %d aligned reads...' %d)
             sys.stdout.flush()
+
+    # Handle the data for the last cell barcode combination
+    df = pd.DataFrame({'cell_barcodes':cell_barcodes,
+                       'umi':umis,
+                       'gene':pd.Series(genes),
+                       'exonic':exonic_assignments,
+                       'umi_quality':umi_quals})
+    df_collapsed = collapse_umis_dataframe(df)
+    df_collapsed = df_collapsed.reset_index()
+    df_collapsed.columns = ['gene','umi','counts']
+    exonic_fraction = df.groupby(['gene','umi']).exonic.mean()
+    df_collapsed.loc[:,'exonic'] = exonic_fraction.loc[list(zip(df_collapsed.gene.values,
+                                                             df_collapsed.umi.values))].values>0.5
+    df_collapsed['cell_barcode'] = cell_barcodes[0]
+    df_collapsed.loc[:,'gene_name'] = df_collapsed.gene.apply(lambda s:gene_id_to_name[s])
+    df_collapsed.loc[:,'genome'] = df_collapsed.gene.apply(lambda s:gene_id_to_genome[s])
+    df_collapsed[['cell_barcode','genome','gene','gene_name','umi','counts','exonic']].to_csv(output_filename,
+                                                   header=False,
+                                                   index=False,
+                                                   mode='a')
+
     samfile.close()
 
 def join_read_assignment_files(output_dir, nthreads):


### PR DESCRIPTION
The last cell barcode combination is never handled. This is most evident when processing small samples, where major cell barcode combinations are missing from the read_assignment.csv file.  It's likely negligible for large/normal data where the only data that's lost is most likely a mismatched barcode combination.

I discovered this bug when processing a small real test run where of the 16 expected cell barcode combinations, 3 were missing.  Those cell barcode combinations were present both in the input fastq files and in the alignment files.  After implementing this fix, all 16 were present in the read_assignment.csv file and the samples' total counts went up significantly.

It also prevents errors like `ValueError: cannot reshape array of size 0 into shape (0,newaxis)`.

Resolves issue #21.