### PR TITLE
Single well sample

### DIFF
--- a/split_seq/analysis.py
+++ b/split_seq/analysis.py
@@ -186,8 +186,8 @@ def parse_wells(s):
                 start = b
                 s_row = row_letter_to_number[start[:1]]
                 s_col = int(start[1:])-1
-                e_row = s_row
-                e_col = s_col
+                e_row = row_letter_to_number[start[:1]]
+                e_col = int(start[1:])
                 sub_wells += list(wells[s_row:e_row+1,s_col:e_col].flatten())
         sub_wells = list(np.unique(sub_wells))
     except:

--- a/split_seq/analysis.py
+++ b/split_seq/analysis.py
@@ -182,6 +182,13 @@ def parse_wells(s):
                 e_row = row_letter_to_number[end[:1]]
                 e_col = int(end[1:])-1
                 sub_wells += list(np.arange(wells[s_row,s_col],wells[e_row,e_col]+1))
+            else:
+                start = b
+                s_row = row_letter_to_number[start[:1]]
+                s_col = int(start[1:])-1
+                e_row = s_row
+                e_col = s_col
+                sub_wells += list(wells[s_row:e_row+1,s_col:e_col].flatten())
         sub_wells = list(np.unique(sub_wells))
     except:
         sub_wells = 'Failed'


### PR DESCRIPTION
This adds support for specifying a single sample in a single well as, for example, `--sample name A1`.

I ran into issues with the straight-forward assumption that such a way to designate a sample's well(s) would be valid, given comma-delimiting is apparently supported, but the errors you run into are not directly revelatory as to the problem.  So I have made this edit in our copy of the code and it works.